### PR TITLE
Make jaxb a private package

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -62,6 +62,21 @@
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
     </dependencies>
 
     <profiles>
@@ -244,6 +259,9 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Private-Package>
+                            com.sun.xml.bind.*
+                        </Private-Package>
                         <Export-Package>
                             org.wso2.extension.siddhi.store.cassandra.*
                         </Export-Package>


### PR DESCRIPTION
Fixes jaxb classes not loading from the environment, 
```
Caused by: java.lang.ClassNotFoundException: com.sun.xml.bind.v2.model.annotation.AnnotationReader cannot be found by com.sun.xml.bind.jaxb-impl_2.3.0
```